### PR TITLE
Add global scripts

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -1318,6 +1318,9 @@ window.onload = function () {
  */
 //==============================================================================
 function checkIfPlayerIsAtGoal() {
-  console.log(this.isATouchingB(this.refs["player"], this.refs["goal"]));
+  if (this.isATouchingB(this.refs["player"], this.refs["goal"])) {
+    alert("You win!");
+    clearInterval(this.runCycle);
+  }
 }
 //==============================================================================

--- a/app/main.js
+++ b/app/main.js
@@ -24,9 +24,9 @@ var App = function () {
 
     //Bind functions to 'this' reference.
     //--------------------------------
-    this.run = this.run.bind(this);
-    this.physics = this.physics.bind(this);
-    this.paint = this.paint.bind(this);
+    //this.run = this.run.bind(this);
+    //this.physics = this.physics.bind(this);
+    //this.paint = this.paint.bind(this);
     //--------------------------------
 
     //Initialise properties
@@ -51,6 +51,10 @@ var App = function () {
     };
     this.actors = [];
     this.areasOfEffect = [];
+    this.refs = {};
+    this.scripts = {
+      onRun: [checkIfPlayerIsAtGoal]
+    };
     //--------------------------------
 
     //Prepare Input
@@ -159,11 +163,11 @@ var App = function () {
 
     //TEST: In-Game Objects
     //--------------------------------
-    this.player = new Actor("player", this.width / 2, this.height / 2, 32, SHAPE_CIRCLE, true);
-    this.player.spritesheet = new ImageAsset("assets/actor.png");
-    this.player.animationStep = 0;
-    this.player.animationSet = this.animationSets["actor"];
-    this.actors.push(this.player);
+    this.refs["player"] = new Actor("player", this.width / 2, this.height / 2, 32, SHAPE_CIRCLE, true);
+    this.refs["player"].spritesheet = new ImageAsset("assets/actor.png");
+    this.refs["player"].animationStep = 0;
+    this.refs["player"].animationSet = this.animationSets["actor"];
+    this.actors.push(this.refs["player"]);
 
     this.actors.push(new Actor("s1", Math.floor(Math.random() * this.width * 0.8) + this.width * 0.1, Math.floor(Math.random() * this.height * 0.8) + this.height * 0.1, 32 + Math.random() * 64, SHAPE_SQUARE));
     this.actors.push(new Actor("s2", Math.floor(Math.random() * this.width * 0.8) + this.width * 0.1, Math.floor(Math.random() * this.height * 0.8) + this.height * 0.1, 32 + Math.random() * 64, SHAPE_SQUARE));
@@ -182,18 +186,15 @@ var App = function () {
     wallN.canBeMoved = false;
     this.actors.push(wallE, wallS, wallW, wallN);
 
-    this.actors[0].canBeMoved = true;
-    this.actors[1].canBeMoved = true;
-    this.actors[2].canBeMoved = true;
-    this.actors[3].canBeMoved = true;
-    this.actors[4].canBeMoved = true;
+    this.areasOfEffect.push(new AoE("conveyorBelt", this.width / 2, this.height / 2 + 64, 64, SHAPE_SQUARE, DURATION_INFINITE, [new Effect("push", { x: 0, y: 4 }, 1, STACKING_RULE_ADD, null)], null));
 
-    this.areasOfEffect.push(new AoE("aoe1", this.width / 2, this.height / 2 + 64, 64, SHAPE_SQUARE, DURATION_INFINITE, [new Effect("push", { x: 0, y: 4 }, 1, STACKING_RULE_ADD, null)], null));
+    this.refs["goal"] = new AoE("goal", this.width / 2, this.height / 2 - 256, 64, SHAPE_SQUARE, DURATION_INFINITE, [], null);
+    this.areasOfEffect.push(this.refs["goal"]);
     //--------------------------------
 
     //Start!
     //--------------------------------
-    this.runCycle = setInterval(this.run, 1000 / FRAMES_PER_SECOND);
+    this.runCycle = setInterval(this.run.bind(this), 1000 / FRAMES_PER_SECOND);
     //--------------------------------
   }
 
@@ -202,6 +203,11 @@ var App = function () {
   _createClass(App, [{
     key: "run",
     value: function run() {
+      this.run_game();
+    }
+  }, {
+    key: "run_game",
+    value: function run_game() {
       //TEST: Input & Actions
       //--------------------------------
       var playerIsIdle = true;
@@ -214,9 +220,9 @@ var App = function () {
         if (dist >= INPUT_DISTANCE_SENSITIVITY * this.sizeRatioY) {
           var angle = Math.atan2(distY, distX);
           var speed = PLAYER_SPEED;
-          this.player.x += Math.cos(angle) * speed;
-          this.player.y += Math.sin(angle) * speed;
-          this.player.rotation = angle;
+          this.refs["player"].x += Math.cos(angle) * speed;
+          this.refs["player"].y += Math.sin(angle) * speed;
+          this.refs["player"].rotation = angle;
           playerIsIdle = false;
 
           //UX improvement: reset the base point of the pointer so the player can
@@ -229,106 +235,79 @@ var App = function () {
       }
 
       if (this.keys[KEY_CODES.UP].state === INPUT_ACTIVE && this.keys[KEY_CODES.DOWN].state !== INPUT_ACTIVE) {
-        this.player.y -= PLAYER_SPEED;
-        this.player.direction = DIRECTION_NORTH;
+        this.refs["player"].y -= PLAYER_SPEED;
+        this.refs["player"].direction = DIRECTION_NORTH;
         playerIsIdle = false;
       } else if (this.keys[KEY_CODES.UP].state !== INPUT_ACTIVE && this.keys[KEY_CODES.DOWN].state === INPUT_ACTIVE) {
-        this.player.y += PLAYER_SPEED;
-        this.player.direction = DIRECTION_SOUTH;
+        this.refs["player"].y += PLAYER_SPEED;
+        this.refs["player"].direction = DIRECTION_SOUTH;
         playerIsIdle = false;
       }
       if (this.keys[KEY_CODES.LEFT].state === INPUT_ACTIVE && this.keys[KEY_CODES.RIGHT].state !== INPUT_ACTIVE) {
-        this.player.x -= PLAYER_SPEED;
-        this.player.direction = DIRECTION_WEST;
+        this.refs["player"].x -= PLAYER_SPEED;
+        this.refs["player"].direction = DIRECTION_WEST;
         playerIsIdle = false;
       } else if (this.keys[KEY_CODES.LEFT].state !== INPUT_ACTIVE && this.keys[KEY_CODES.RIGHT].state === INPUT_ACTIVE) {
-        this.player.x += PLAYER_SPEED;
-        this.player.direction = DIRECTION_EAST;
+        this.refs["player"].x += PLAYER_SPEED;
+        this.refs["player"].direction = DIRECTION_EAST;
         playerIsIdle = false;
       }
 
       if (this.keys[KEY_CODES.A].state === INPUT_ACTIVE && this.keys[KEY_CODES.D].state !== INPUT_ACTIVE) {
-        this.player.rotation -= Math.PI / 36;
+        this.refs["player"].rotation -= Math.PI / 36;
         playerIsIdle = false;
       } else if (this.keys[KEY_CODES.A].state !== INPUT_ACTIVE && this.keys[KEY_CODES.D].state === INPUT_ACTIVE) {
-        this.player.rotation += Math.PI / 36;
+        this.refs["player"].rotation += Math.PI / 36;
         playerIsIdle = false;
       }
 
       if (this.keys[KEY_CODES.W].state === INPUT_ACTIVE) {
-        this.player.x += Math.cos(this.player.rotation) * PLAYER_SPEED;
-        this.player.y += Math.sin(this.player.rotation) * PLAYER_SPEED;
+        this.refs["player"].x += Math.cos(this.refs["player"].rotation) * PLAYER_SPEED;
+        this.refs["player"].y += Math.sin(this.refs["player"].rotation) * PLAYER_SPEED;
         playerIsIdle = false;
       } else if (this.keys[KEY_CODES.S].state === INPUT_ACTIVE) {
-        this.player.x -= Math.cos(this.player.rotation) * PLAYER_SPEED;
-        this.player.y -= Math.sin(this.player.rotation) * PLAYER_SPEED;
+        this.refs["player"].x -= Math.cos(this.refs["player"].rotation) * PLAYER_SPEED;
+        this.refs["player"].y -= Math.sin(this.refs["player"].rotation) * PLAYER_SPEED;
         playerIsIdle = false;
       }
 
       if (this.keys[KEY_CODES.Z].duration === 1) {
-        this.player.shape = this.player.shape === SHAPE_CIRCLE ? SHAPE_SQUARE : SHAPE_CIRCLE;
+        this.refs["player"].shape = this.refs["player"].shape === SHAPE_CIRCLE ? SHAPE_SQUARE : SHAPE_CIRCLE;
       }
 
       if (this.keys[KEY_CODES.SPACE].duration === 1) {
         var PUSH_POWER = 12;
-        var AOE_SIZE = this.player.size;
-        var distance = this.player.radius + AOE_SIZE / 2;
-        var x = this.player.x + Math.cos(this.player.rotation) * distance;
-        var y = this.player.y + Math.sin(this.player.rotation) * distance;;
-        var newAoE = new AoE("", x, y, AOE_SIZE, SHAPE_CIRCLE, 5, [new Effect("push", { x: Math.cos(this.player.rotation) * PUSH_POWER, y: Math.sin(this.player.rotation) * PUSH_POWER }, 2, STACKING_RULE_ADD, this.player)], this.player);
+        var AOE_SIZE = this.refs["player"].size;
+        var distance = this.refs["player"].radius + AOE_SIZE / 2;
+        var x = this.refs["player"].x + Math.cos(this.refs["player"].rotation) * distance;
+        var y = this.refs["player"].y + Math.sin(this.refs["player"].rotation) * distance;;
+        var newAoE = new AoE("", x, y, AOE_SIZE, SHAPE_CIRCLE, 5, [new Effect("push", { x: Math.cos(this.refs["player"].rotation) * PUSH_POWER, y: Math.sin(this.refs["player"].rotation) * PUSH_POWER }, 2, STACKING_RULE_ADD, this.refs["player"])], this.refs["player"]);
         this.areasOfEffect.push(newAoE);
       }
 
       //Try animation!
       if (playerIsIdle) {
-        this.player.playAnimation("idle");
+        this.refs["player"].playAnimation("idle");
       } else {
-        this.player.playAnimation("walk");
+        this.refs["player"].playAnimation("walk");
       }
-
       //--------------------------------
 
-      //AoEs apply Effects
+      //Run Global Scripts
       //--------------------------------
       var _iteratorNormalCompletion2 = true;
       var _didIteratorError2 = false;
       var _iteratorError2 = undefined;
 
       try {
-        for (var _iterator2 = this.areasOfEffect[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
-          var _aoe = _step2.value;
-          var _iteratorNormalCompletion5 = true;
-          var _didIteratorError5 = false;
-          var _iteratorError5 = undefined;
+        for (var _iterator2 = this.scripts.onRun[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
+          var script = _step2.value;
 
-          try {
-            for (var _iterator5 = this.actors[Symbol.iterator](), _step5; !(_iteratorNormalCompletion5 = (_step5 = _iterator5.next()).done); _iteratorNormalCompletion5 = true) {
-              var actor = _step5.value;
-
-              if (this.isATouchingB(_aoe, actor)) {
-                var _actor$effects;
-
-                (_actor$effects = actor.effects).push.apply(_actor$effects, _toConsumableArray(_aoe.effects)); //Array.push can push multiple elements.
-              }
-            }
-          } catch (err) {
-            _didIteratorError5 = true;
-            _iteratorError5 = err;
-          } finally {
-            try {
-              if (!_iteratorNormalCompletion5 && _iterator5.return) {
-                _iterator5.return();
-              }
-            } finally {
-              if (_didIteratorError5) {
-                throw _iteratorError5;
-              }
-            }
-          }
+          script.apply(this);
         }
         //--------------------------------
 
-        //Actors react to Effects
+        //AoEs apply Effects
         //--------------------------------
       } catch (err) {
         _didIteratorError2 = true;
@@ -350,19 +329,20 @@ var App = function () {
       var _iteratorError3 = undefined;
 
       try {
-        for (var _iterator3 = this.actors[Symbol.iterator](), _step3; !(_iteratorNormalCompletion3 = (_step3 = _iterator3.next()).done); _iteratorNormalCompletion3 = true) {
-          var _actor = _step3.value;
+        for (var _iterator3 = this.areasOfEffect[Symbol.iterator](), _step3; !(_iteratorNormalCompletion3 = (_step3 = _iterator3.next()).done); _iteratorNormalCompletion3 = true) {
+          var _aoe = _step3.value;
           var _iteratorNormalCompletion6 = true;
           var _didIteratorError6 = false;
           var _iteratorError6 = undefined;
 
           try {
-            for (var _iterator6 = _actor.effects[Symbol.iterator](), _step6; !(_iteratorNormalCompletion6 = (_step6 = _iterator6.next()).done); _iteratorNormalCompletion6 = true) {
-              var effect = _step6.value;
+            for (var _iterator6 = this.actors[Symbol.iterator](), _step6; !(_iteratorNormalCompletion6 = (_step6 = _iterator6.next()).done); _iteratorNormalCompletion6 = true) {
+              var actor = _step6.value;
 
-              if (effect.name === "push" && _actor.canBeMoved) {
-                _actor.x += effect.data.x || 0;
-                _actor.y += effect.data.y || 0;
+              if (this.isATouchingB(_aoe, actor)) {
+                var _actor$effects;
+
+                (_actor$effects = actor.effects).push.apply(_actor$effects, _toConsumableArray(_aoe.effects)); //Array.push can push multiple elements.
               }
             }
           } catch (err) {
@@ -382,7 +362,7 @@ var App = function () {
         }
         //--------------------------------
 
-        //Physics
+        //Actors react to Effects
         //--------------------------------
       } catch (err) {
         _didIteratorError3 = true;
@@ -399,6 +379,60 @@ var App = function () {
         }
       }
 
+      var _iteratorNormalCompletion4 = true;
+      var _didIteratorError4 = false;
+      var _iteratorError4 = undefined;
+
+      try {
+        for (var _iterator4 = this.actors[Symbol.iterator](), _step4; !(_iteratorNormalCompletion4 = (_step4 = _iterator4.next()).done); _iteratorNormalCompletion4 = true) {
+          var _actor = _step4.value;
+          var _iteratorNormalCompletion7 = true;
+          var _didIteratorError7 = false;
+          var _iteratorError7 = undefined;
+
+          try {
+            for (var _iterator7 = _actor.effects[Symbol.iterator](), _step7; !(_iteratorNormalCompletion7 = (_step7 = _iterator7.next()).done); _iteratorNormalCompletion7 = true) {
+              var effect = _step7.value;
+
+              if (effect.name === "push" && _actor.canBeMoved) {
+                _actor.x += effect.data.x || 0;
+                _actor.y += effect.data.y || 0;
+              }
+            }
+          } catch (err) {
+            _didIteratorError7 = true;
+            _iteratorError7 = err;
+          } finally {
+            try {
+              if (!_iteratorNormalCompletion7 && _iterator7.return) {
+                _iterator7.return();
+              }
+            } finally {
+              if (_didIteratorError7) {
+                throw _iteratorError7;
+              }
+            }
+          }
+        }
+        //--------------------------------
+
+        //Physics
+        //--------------------------------
+      } catch (err) {
+        _didIteratorError4 = true;
+        _iteratorError4 = err;
+      } finally {
+        try {
+          if (!_iteratorNormalCompletion4 && _iterator4.return) {
+            _iterator4.return();
+          }
+        } finally {
+          if (_didIteratorError4) {
+            throw _iteratorError4;
+          }
+        }
+      }
+
       this.physics();
       //--------------------------------
 
@@ -406,7 +440,7 @@ var App = function () {
       //--------------------------------
       //Arrange sprites by vertical order.
       this.actors.sort(function (a, b) {
-        return a.y < b.y;
+        return a.bottom < b.bottom;
       });
 
       this.paint();
@@ -427,13 +461,13 @@ var App = function () {
 
       //Cleanup Effects
       //--------------------------------
-      var _iteratorNormalCompletion4 = true;
-      var _didIteratorError4 = false;
-      var _iteratorError4 = undefined;
+      var _iteratorNormalCompletion5 = true;
+      var _didIteratorError5 = false;
+      var _iteratorError5 = undefined;
 
       try {
-        for (var _iterator4 = this.actors[Symbol.iterator](), _step4; !(_iteratorNormalCompletion4 = (_step4 = _iterator4.next()).done); _iteratorNormalCompletion4 = true) {
-          var _actor2 = _step4.value;
+        for (var _iterator5 = this.actors[Symbol.iterator](), _step5; !(_iteratorNormalCompletion5 = (_step5 = _iterator5.next()).done); _iteratorNormalCompletion5 = true) {
+          var _actor2 = _step5.value;
 
           for (var _i3 = _actor2.effects.length - 1; _i3 >= 0; _i3--) {
             if (!_actor2.effects[_i3].hasInfiniteDuration()) {
@@ -449,16 +483,16 @@ var App = function () {
         //Cleanup Input
         //--------------------------------
       } catch (err) {
-        _didIteratorError4 = true;
-        _iteratorError4 = err;
+        _didIteratorError5 = true;
+        _iteratorError5 = err;
       } finally {
         try {
-          if (!_iteratorNormalCompletion4 && _iterator4.return) {
-            _iterator4.return();
+          if (!_iteratorNormalCompletion5 && _iterator5.return) {
+            _iterator5.return();
           }
         } finally {
-          if (_didIteratorError4) {
-            throw _iteratorError4;
+          if (_didIteratorError5) {
+            throw _iteratorError5;
           }
         }
       }
@@ -600,13 +634,13 @@ var App = function () {
       this.context2d.clearRect(0, 0, this.width, this.height);
 
       //Pain Areas of Effects
-      var _iteratorNormalCompletion7 = true;
-      var _didIteratorError7 = false;
-      var _iteratorError7 = undefined;
+      var _iteratorNormalCompletion8 = true;
+      var _didIteratorError8 = false;
+      var _iteratorError8 = undefined;
 
       try {
-        for (var _iterator7 = this.areasOfEffect[Symbol.iterator](), _step7; !(_iteratorNormalCompletion7 = (_step7 = _iterator7.next()).done); _iteratorNormalCompletion7 = true) {
-          var aoe = _step7.value;
+        for (var _iterator8 = this.areasOfEffect[Symbol.iterator](), _step8; !(_iteratorNormalCompletion8 = (_step8 = _iterator8.next()).done); _iteratorNormalCompletion8 = true) {
+          var aoe = _step8.value;
 
           var durationPercentage = 1;
           if (!aoe.hasInfiniteDuration() && aoe.startDuration > 0) {
@@ -636,28 +670,28 @@ var App = function () {
 
         //Paint Actor hitboxes
       } catch (err) {
-        _didIteratorError7 = true;
-        _iteratorError7 = err;
+        _didIteratorError8 = true;
+        _iteratorError8 = err;
       } finally {
         try {
-          if (!_iteratorNormalCompletion7 && _iterator7.return) {
-            _iterator7.return();
+          if (!_iteratorNormalCompletion8 && _iterator8.return) {
+            _iterator8.return();
           }
         } finally {
-          if (_didIteratorError7) {
-            throw _iteratorError7;
+          if (_didIteratorError8) {
+            throw _iteratorError8;
           }
         }
       }
 
       this.context2d.strokeStyle = "rgba(0,0,0,1)";
-      var _iteratorNormalCompletion8 = true;
-      var _didIteratorError8 = false;
-      var _iteratorError8 = undefined;
+      var _iteratorNormalCompletion9 = true;
+      var _didIteratorError9 = false;
+      var _iteratorError9 = undefined;
 
       try {
-        for (var _iterator8 = this.actors[Symbol.iterator](), _step8; !(_iteratorNormalCompletion8 = (_step8 = _iterator8.next()).done); _iteratorNormalCompletion8 = true) {
-          var actor = _step8.value;
+        for (var _iterator9 = this.actors[Symbol.iterator](), _step9; !(_iteratorNormalCompletion9 = (_step9 = _iterator9.next()).done); _iteratorNormalCompletion9 = true) {
+          var actor = _step9.value;
 
           switch (actor.shape) {
             case SHAPE_CIRCLE:
@@ -682,27 +716,27 @@ var App = function () {
 
         //Paint sprites
       } catch (err) {
-        _didIteratorError8 = true;
-        _iteratorError8 = err;
+        _didIteratorError9 = true;
+        _iteratorError9 = err;
       } finally {
         try {
-          if (!_iteratorNormalCompletion8 && _iterator8.return) {
-            _iterator8.return();
+          if (!_iteratorNormalCompletion9 && _iterator9.return) {
+            _iterator9.return();
           }
         } finally {
-          if (_didIteratorError8) {
-            throw _iteratorError8;
+          if (_didIteratorError9) {
+            throw _iteratorError9;
           }
         }
       }
 
-      var _iteratorNormalCompletion9 = true;
-      var _didIteratorError9 = false;
-      var _iteratorError9 = undefined;
+      var _iteratorNormalCompletion10 = true;
+      var _didIteratorError10 = false;
+      var _iteratorError10 = undefined;
 
       try {
-        for (var _iterator9 = this.actors[Symbol.iterator](), _step9; !(_iteratorNormalCompletion9 = (_step9 = _iterator9.next()).done); _iteratorNormalCompletion9 = true) {
-          var _actor3 = _step9.value;
+        for (var _iterator10 = this.actors[Symbol.iterator](), _step10; !(_iteratorNormalCompletion10 = (_step10 = _iterator10.next()).done); _iteratorNormalCompletion10 = true) {
+          var _actor3 = _step10.value;
 
           if (!_actor3.spritesheet || !_actor3.spritesheet.loaded || !_actor3.animationSet || !_actor3.animationSet.actions[_actor3.animationName]) continue;
 
@@ -720,16 +754,16 @@ var App = function () {
           this.context2d.drawImage(_actor3.spritesheet.img, srcX, srcY, srcW, srcH, tgtX, tgtY, tgtW, tgtH);
         }
       } catch (err) {
-        _didIteratorError9 = true;
-        _iteratorError9 = err;
+        _didIteratorError10 = true;
+        _iteratorError10 = err;
       } finally {
         try {
-          if (!_iteratorNormalCompletion9 && _iterator9.return) {
-            _iterator9.return();
+          if (!_iteratorNormalCompletion10 && _iterator10.return) {
+            _iterator10.return();
           }
         } finally {
-          if (_didIteratorError9) {
-            throw _iteratorError9;
+          if (_didIteratorError10) {
+            throw _iteratorError10;
           }
         }
       }
@@ -1278,4 +1312,12 @@ var app;
 window.onload = function () {
   window.app = new App();
 };
+//==============================================================================
+
+/*  Global Scripts
+ */
+//==============================================================================
+function checkIfPlayerIsAtGoal() {
+  console.log(this.isATouchingB(this.refs["player"], this.refs["goal"]));
+}
 //==============================================================================

--- a/src/main.js
+++ b/src/main.js
@@ -1006,6 +1006,9 @@ window.onload = function() {
  */
 //==============================================================================
 function checkIfPlayerIsAtGoal() {
-  console.log(this.isATouchingB(this.refs["player"], this.refs["goal"]));
+  if (this.isATouchingB(this.refs["player"], this.refs["goal"])) {
+    alert("You win!");
+    clearInterval(this.runCycle);    
+  }
 }
 //==============================================================================


### PR DESCRIPTION
We now have a new mechanism for adding 'global scripts', e.g. scripts that run at every tick of the clock (on every iteration of the run cycle). This is useful if we're, e.g., always checking the win/lose condition.

In this example, moving the player to the "goal" at the north will trigger a win message and end the game.
